### PR TITLE
Implement deduplication, batch posting

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,2 @@
+test:
+	python3 -m pytest

--- a/Makefile
+++ b/Makefile
@@ -1,2 +1,5 @@
 test:
 	python3 -m pytest
+
+deps-debian:
+	apt -y install python3-requests python3-termcolor python3-ais

--- a/ais_json.py
+++ b/ais_json.py
@@ -126,7 +126,7 @@ def post_jsonais(url, output):
     """POST a jsonais output dict to the given URL. Returns the response."""
     post = json.dumps(output)
     print(post)
-    r = requests.post(url, files={'jsonais': (None, post)})
+    r = requests.post(url, files={'jsonais': (None, post)}, timeout=30)
     return r
 
 

--- a/ais_json.py
+++ b/ais_json.py
@@ -4,11 +4,16 @@ import warnings
 warnings.simplefilter(action='ignore', category=FutureWarning)
 import json
 import datetime
+import time
+import random
 import requests
 
+POSITION_TYPES = {1, 2, 3, 18}
+POSITION_DEDUP_INTERVAL = 120  # seconds
 
-def parsed_to_jsonais(parsed, name, url, rxtime=None):
-    """Convert a parsed AIS message dict to a jsonais output dict."""
+
+def parsed_to_ais_msg(parsed, rxtime=None):
+    """Convert a parsed AIS message dict to an ais_msg dict."""
     if rxtime is None:
         rxtime = datetime.datetime.utcnow().strftime("%Y%m%d%H%M%S")
 
@@ -55,13 +60,21 @@ def parsed_to_jsonais(parsed, name, url, rxtime=None):
     if 'persons' in parsed:
       ais_msg['persons_on_board'] = parsed['persons']
 
+    return ais_msg
+
+
+def build_jsonais_batch(msgs, name, url, rxtime=None):
+    """Wrap a list of ais_msg dicts into a jsonais output structure."""
+    if rxtime is None:
+        rxtime = datetime.datetime.utcnow().strftime("%Y%m%d%H%M%S")
+
     path = {
             "name": name,
             "url": url }
 
     groups = {
             "path": [path],
-            "msgs": [ais_msg] }
+            "msgs": msgs }
 
     output = {
             "encodetime": rxtime,
@@ -70,6 +83,39 @@ def parsed_to_jsonais(parsed, name, url, rxtime=None):
             }
 
     return output
+
+
+def parsed_to_jsonais(parsed, name, url, rxtime=None):
+    """Convert a parsed AIS message dict to a jsonais output dict."""
+    ais_msg = parsed_to_ais_msg(parsed, rxtime=rxtime)
+    return build_jsonais_batch([ais_msg], name, url, rxtime=rxtime)
+
+
+class AISCache:
+    def __init__(self, dedup_interval=POSITION_DEDUP_INTERVAL):
+        self.cache = {}              # (mmsi, msgtype) -> ais_msg
+        self.last_sent_pos = {}      # mmsi -> (lon, lat, monotonic_time)
+        self.dedup_interval = dedup_interval
+
+    def add(self, ais_msg):
+        key = (ais_msg['mmsi'], ais_msg['msgtype'])
+        self.cache[key] = ais_msg
+
+    def flush(self, now=None):
+        if now is None:
+            now = time.monotonic()
+        msgs = []
+        for (mmsi, msgtype), msg in self.cache.items():
+            if msgtype in POSITION_TYPES:
+                pos = (msg.get('lon'), msg.get('lat'))
+                last = self.last_sent_pos.get(mmsi)
+                if last and last[0] == pos[0] and last[1] == pos[1] \
+                        and (now - last[2]) < self.dedup_interval:
+                    continue
+                self.last_sent_pos[mmsi] = (pos[0], pos[1], now)
+            msgs.append(msg)
+        self.cache.clear()
+        return msgs
 
 
 def post_jsonais(url, output):
@@ -92,21 +138,22 @@ if __name__ == '__main__':
     sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
     sock.bind((IP, PORT))
 
+    cache = AISCache()
+    next_send = time.monotonic() + 28 + random.uniform(0, 4)
+
     while True:
       for msg in ais.stream.decode(sock.makefile('r'), keep_nmea=True):
         parsed = json.loads(json.dumps(msg))
-        output = parsed_to_jsonais(parsed, NAME, URL)
+        ais_msg = parsed_to_ais_msg(parsed)
+        cache.add(ais_msg)
 
-        try:
-          r = post_jsonais(URL, output)
-          #dump non common packets for debugging
-          if parsed['id'] not in (1, 2, 3, 4):
-            print('Error')
-            print(colored('-- Uncommon packet recieved\n', 'red'))
-            print(colored('id:', 'green'), parsed['id'])
-            print(colored('NMEA:', 'green'), parsed['nmea'])
-            print(colored('Parsed:', 'green'), parsed)
-            print(colored('Post:', 'green'), json.dumps(output))
-            print(colored('Result:', 'green'), json.loads(r.text)['description'])
-        except requests.exceptions.RequestException as e:
-          print(e)
+        now = time.monotonic()
+        if now >= next_send:
+          msgs = cache.flush(now)
+          if msgs:
+            output = build_jsonais_batch(msgs, NAME, URL)
+            try:
+              post_jsonais(URL, output)
+            except requests.exceptions.RequestException as e:
+              print(e)
+          next_send = now + 28 + random.uniform(0, 4)

--- a/ais_json.py
+++ b/ais_json.py
@@ -2,97 +2,111 @@
 
 import warnings
 warnings.simplefilter(action='ignore', category=FutureWarning)
-from termcolor import colored
-from settings import URL, NAME
 import json
-import ais.stream
-import socket
 import datetime
 import requests
 
-IP = '127.0.0.1'
-PORT = 5000
 
-sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
-sock.bind((IP, PORT))
+def parsed_to_jsonais(parsed, name, url, rxtime=None):
+    """Convert a parsed AIS message dict to a jsonais output dict."""
+    if rxtime is None:
+        rxtime = datetime.datetime.utcnow().strftime("%Y%m%d%H%M%S")
 
-while True:
-
-  for msg in ais.stream.decode(sock.makefile('r'),keep_nmea=True):
-    rxtime =  datetime.datetime.utcnow().strftime("%Y%m%d%H%M%S") #YYYYMMDDHHMMSS
-    parsed = json.loads(json.dumps(msg))
-    
-    ais = {
+    ais_msg = {
             'msgtype': parsed['id'],
             'mmsi': parsed['mmsi'],
             'rxtime': rxtime
             }
 
     if 'x' in parsed:
-      ais['lon'] = parsed['x']
+      ais_msg['lon'] = parsed['x']
     if 'y' in parsed:
-      ais['lat'] = parsed['y']
+      ais_msg['lat'] = parsed['y']
     if 'sog' in parsed:
-      ais['speed'] = parsed['sog']
+      ais_msg['speed'] = parsed['sog']
     if 'cog' in parsed:
-      ais['course'] = parsed['cog']
+      ais_msg['course'] = parsed['cog']
     if 'true_heading' in parsed:
-      ais['heading'] = parsed['true_heading']
+      ais_msg['heading'] = parsed['true_heading']
     if 'nav_status' in parsed:
-      ais['status'] = parsed['nav_status']
+      ais_msg['status'] = parsed['nav_status']
     if 'type_and_cargo' in parsed:
-      ais['shiptype'] = parsed['type_and_cargo']
+      ais_msg['shiptype'] = parsed['type_and_cargo']
     if 'part_num' in parsed:
-      ais['partno'] = parsed['part_num']
+      ais_msg['partno'] = parsed['part_num']
     if 'callsign' in parsed:
-      ais['callsign'] = parsed['callsign']
+      ais_msg['callsign'] = parsed['callsign']
     if 'name' in parsed:
-      ais['shipname'] = parsed['name']
+      ais_msg['shipname'] = parsed['name']
     if 'vendor_id' in parsed:
-      ais['vendorid'] = parsed['vendor_id']
+      ais_msg['vendorid'] = parsed['vendor_id']
     if 'dim_a' in parsed:
-      ais['ref_front'] = parsed['dim_a']
+      ais_msg['ref_front'] = parsed['dim_a']
     if 'dim_c' in parsed:
-      ais['ref_left'] = parsed['dim_c']
+      ais_msg['ref_left'] = parsed['dim_c']
     if 'draught' in parsed:
-      ais['draught'] = parsed['draught']
+      ais_msg['draught'] = parsed['draught']
     if 'length' in parsed:
-      ais['length'] = parsed['length']
+      ais_msg['length'] = parsed['length']
     if 'width' in parsed:
-      ais['width'] = parsed['width']
+      ais_msg['width'] = parsed['width']
     if 'destination' in parsed:
-      ais['destination'] = parsed['destination']
+      ais_msg['destination'] = parsed['destination']
     if 'persons' in parsed:
-      ais['persons_on_board'] = parsed['persons']
+      ais_msg['persons_on_board'] = parsed['persons']
 
-    path = { 
-            "name": NAME, 
-            "url": URL }
+    path = {
+            "name": name,
+            "url": url }
 
-    groups = { 
-            "path": [path], 
-            "msgs":[ais] }
-    
+    groups = {
+            "path": [path],
+            "msgs": [ais_msg] }
+
     output = {
             "encodetime": rxtime,
             "protocol": 'jsonais',
-            "groups":  [groups]
+            "groups": [groups]
             }
-    
-    post = json.dumps(output)
-   #print what's posted
-    print (post)
-    try:
-      r = requests.post(URL, files={'jsonais': (None, post)})
-      #dump non common packets for debugging
-      if parsed['id'] not in (1,2,3,4):
-        print ('Error')
-        print (colored('-- Uncommon packet recieved\n', 'red'))
-        print (colored('id:', 'green'), parsed['id'])
-        print (colored('NMEA:', 'green'), parsed['nmea'])
-        print (colored('Parsed:', 'green'), parsed)
-        print (colored('Post:', 'green'), post)
-        print (colored('Result:', 'green'), json.loads(r.text)['description'])
-    except requests.exceptions.RequestException as e:
-      print (e)
 
+    return output
+
+
+def post_jsonais(url, output):
+    """POST a jsonais output dict to the given URL. Returns the response."""
+    post = json.dumps(output)
+    print(post)
+    r = requests.post(url, files={'jsonais': (None, post)})
+    return r
+
+
+if __name__ == '__main__':
+    from termcolor import colored
+    import ais.stream
+    import socket
+    from settings import URL, NAME
+
+    IP = '127.0.0.1'
+    PORT = 5000
+
+    sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+    sock.bind((IP, PORT))
+
+    while True:
+      for msg in ais.stream.decode(sock.makefile('r'), keep_nmea=True):
+        parsed = json.loads(json.dumps(msg))
+        output = parsed_to_jsonais(parsed, NAME, URL)
+
+        try:
+          r = post_jsonais(URL, output)
+          #dump non common packets for debugging
+          if parsed['id'] not in (1, 2, 3, 4):
+            print('Error')
+            print(colored('-- Uncommon packet recieved\n', 'red'))
+            print(colored('id:', 'green'), parsed['id'])
+            print(colored('NMEA:', 'green'), parsed['nmea'])
+            print(colored('Parsed:', 'green'), parsed)
+            print(colored('Post:', 'green'), json.dumps(output))
+            print(colored('Result:', 'green'), json.loads(r.text)['description'])
+        except requests.exceptions.RequestException as e:
+          print(e)

--- a/ais_json.py
+++ b/ais_json.py
@@ -26,9 +26,9 @@ def parsed_to_ais_msg(parsed, rxtime=None):
             }
 
     if 'x' in parsed:
-      ais_msg['lon'] = parsed['x']
+      ais_msg['lon'] = round(parsed['x'], 6)
     if 'y' in parsed:
-      ais_msg['lat'] = parsed['y']
+      ais_msg['lat'] = round(parsed['y'], 6)
     if 'sog' in parsed:
       ais_msg['speed'] = parsed['sog']
     if 'cog' in parsed:
@@ -110,12 +110,13 @@ class AISCache:
         msgs = []
         for (mmsi, msgtype), msg in self.cache.items():
             if msgtype in POSITION_TYPES:
-                pos = (msg.get('lon'), msg.get('lat'))
+                lon = round(msg.get('lon', 0), 6)
+                lat = round(msg.get('lat', 0), 6)
                 last = self.last_sent_pos.get(mmsi)
-                if last and last[0] == pos[0] and last[1] == pos[1] \
+                if last and last[0] == lon and last[1] == lat \
                         and (now - last[2]) < self.dedup_interval:
                     continue
-                self.last_sent_pos[mmsi] = (pos[0], pos[1], now)
+                self.last_sent_pos[mmsi] = (lon, lat, now)
             msgs.append(msg)
         self.cache.clear()
         return msgs

--- a/ais_json.py
+++ b/ais_json.py
@@ -9,6 +9,8 @@ import random
 import requests
 
 POSITION_TYPES = {1, 2, 3, 18}
+# aprs.fi ignores these message types, they do not have position information
+IGNORED_TYPES = {7, 10, 11, 12, 13, 15, 16, 20, 22, 23}
 POSITION_DEDUP_INTERVAL = 120  # seconds
 
 
@@ -97,6 +99,8 @@ class AISCache:
         self.dedup_interval = dedup_interval
 
     def add(self, ais_msg):
+        if ais_msg['msgtype'] in IGNORED_TYPES:
+            return
         key = (ais_msg['mmsi'], ais_msg['msgtype'])
         self.cache[key] = ais_msg
 

--- a/ais_json.py
+++ b/ais_json.py
@@ -63,14 +63,13 @@ def parsed_to_ais_msg(parsed, rxtime=None):
     return ais_msg
 
 
-def build_jsonais_batch(msgs, name, url, rxtime=None):
+def build_jsonais_batch(msgs, name, rxtime=None):
     """Wrap a list of ais_msg dicts into a jsonais output structure."""
     if rxtime is None:
         rxtime = datetime.datetime.utcnow().strftime("%Y%m%d%H%M%S")
 
     path = {
-            "name": name,
-            "url": url }
+            "name": name }
 
     groups = {
             "path": [path],
@@ -85,10 +84,10 @@ def build_jsonais_batch(msgs, name, url, rxtime=None):
     return output
 
 
-def parsed_to_jsonais(parsed, name, url, rxtime=None):
+def parsed_to_jsonais(parsed, name, rxtime=None):
     """Convert a parsed AIS message dict to a jsonais output dict."""
     ais_msg = parsed_to_ais_msg(parsed, rxtime=rxtime)
-    return build_jsonais_batch([ais_msg], name, url, rxtime=rxtime)
+    return build_jsonais_batch([ais_msg], name, rxtime=rxtime)
 
 
 class AISCache:
@@ -151,7 +150,7 @@ if __name__ == '__main__':
         if now >= next_send:
           msgs = cache.flush(now)
           if msgs:
-            output = build_jsonais_batch(msgs, NAME, URL)
+            output = build_jsonais_batch(msgs, NAME)
             try:
               post_jsonais(URL, output)
             except requests.exceptions.RequestException as e:

--- a/test_ais_json.py
+++ b/test_ais_json.py
@@ -1,0 +1,86 @@
+from unittest.mock import patch, MagicMock
+from ais_json import parsed_to_jsonais, post_jsonais
+
+
+def test_parsed_to_jsonais_position_report():
+    parsed = {
+        'id': 1,
+        'mmsi': 211234567,
+        'x': 24.9384,
+        'y': 60.1699,
+        'sog': 12.3,
+        'cog': 45.6,
+        'true_heading': 47,
+        'nav_status': 0,
+    }
+
+    output = parsed_to_jsonais(parsed, 'TestStation', 'http://example.com/post', rxtime='20260223120000')
+
+    assert output['protocol'] == 'jsonais'
+    assert output['encodetime'] == '20260223120000'
+    assert len(output['groups']) == 1
+
+    group = output['groups'][0]
+    assert group['path'] == [{'name': 'TestStation', 'url': 'http://example.com/post'}]
+
+    msg = group['msgs'][0]
+    assert msg['msgtype'] == 1
+    assert msg['mmsi'] == 211234567
+    assert msg['lon'] == 24.9384
+    assert msg['lat'] == 60.1699
+    assert msg['speed'] == 12.3
+    assert msg['course'] == 45.6
+    assert msg['heading'] == 47
+    assert msg['status'] == 0
+    assert msg['rxtime'] == '20260223120000'
+
+
+def test_parsed_to_jsonais_minimal():
+    parsed = {'id': 5, 'mmsi': 123456789}
+
+    output = parsed_to_jsonais(parsed, 'Sta', 'http://x.com', rxtime='20260101000000')
+
+    msg = output['groups'][0]['msgs'][0]
+    assert msg['msgtype'] == 5
+    assert msg['mmsi'] == 123456789
+    assert 'lon' not in msg
+    assert 'lat' not in msg
+
+
+def test_parsed_to_jsonais_static_fields():
+    parsed = {
+        'id': 5,
+        'mmsi': 123456789,
+        'callsign': 'ABCD',
+        'name': 'TESTSHIP',
+        'type_and_cargo': 70,
+        'dim_a': 100,
+        'dim_c': 10,
+        'draught': 5.5,
+        'destination': 'HELSINKI',
+    }
+
+    output = parsed_to_jsonais(parsed, 'Sta', 'http://x.com', rxtime='20260101000000')
+    msg = output['groups'][0]['msgs'][0]
+
+    assert msg['callsign'] == 'ABCD'
+    assert msg['shipname'] == 'TESTSHIP'
+    assert msg['shiptype'] == 70
+    assert msg['ref_front'] == 100
+    assert msg['ref_left'] == 10
+    assert msg['draught'] == 5.5
+    assert msg['destination'] == 'HELSINKI'
+
+
+@patch('ais_json.requests.post')
+def test_post_jsonais(mock_post):
+    mock_post.return_value = MagicMock(status_code=200)
+
+    output = {'protocol': 'jsonais', 'groups': []}
+    r = post_jsonais('http://example.com/post', output)
+
+    mock_post.assert_called_once()
+    call_args = mock_post.call_args
+    assert call_args[0][0] == 'http://example.com/post'
+    assert 'jsonais' in call_args[1]['files']
+    assert r.status_code == 200

--- a/test_ais_json.py
+++ b/test_ais_json.py
@@ -195,3 +195,29 @@ def test_cache_accepts_non_ignored_types():
 
     msgs = cache.flush(now=1000.0)
     assert len(msgs) == 2
+
+
+def test_positions_rounded_to_6_decimals():
+    parsed = {
+        'id': 1,
+        'mmsi': 211234567,
+        'x': 24.93840001,
+        'y': 60.16990009,
+    }
+
+    msg = parsed_to_ais_msg(parsed, rxtime='20260101000000')
+    assert msg['lon'] == 24.93840
+    assert msg['lat'] == 60.16990
+
+
+def test_cache_position_dedup_with_rounding():
+    """Positions differing only beyond 6 decimals should be deduplicated."""
+    cache = AISCache()
+
+    cache.add({'mmsi': 111, 'msgtype': 1, 'lon': 1.000000, 'lat': 2.000000})
+    msgs1 = cache.flush(now=1000.0)
+    assert len(msgs1) == 1
+
+    cache.add({'mmsi': 111, 'msgtype': 1, 'lon': 1.0000001, 'lat': 2.0000001})
+    msgs2 = cache.flush(now=1050.0)
+    assert len(msgs2) == 0

--- a/test_ais_json.py
+++ b/test_ais_json.py
@@ -14,14 +14,14 @@ def test_parsed_to_jsonais_position_report():
         'nav_status': 0,
     }
 
-    output = parsed_to_jsonais(parsed, 'TestStation', 'http://example.com/post', rxtime='20260223120000')
+    output = parsed_to_jsonais(parsed, 'TestStation', rxtime='20260223120000')
 
     assert output['protocol'] == 'jsonais'
     assert output['encodetime'] == '20260223120000'
     assert len(output['groups']) == 1
 
     group = output['groups'][0]
-    assert group['path'] == [{'name': 'TestStation', 'url': 'http://example.com/post'}]
+    assert group['path'] == [{'name': 'TestStation'}]
 
     msg = group['msgs'][0]
     assert msg['msgtype'] == 1
@@ -38,7 +38,7 @@ def test_parsed_to_jsonais_position_report():
 def test_parsed_to_jsonais_minimal():
     parsed = {'id': 5, 'mmsi': 123456789}
 
-    output = parsed_to_jsonais(parsed, 'Sta', 'http://x.com', rxtime='20260101000000')
+    output = parsed_to_jsonais(parsed, 'Sta', rxtime='20260101000000')
 
     msg = output['groups'][0]['msgs'][0]
     assert msg['msgtype'] == 5
@@ -60,7 +60,7 @@ def test_parsed_to_jsonais_static_fields():
         'destination': 'HELSINKI',
     }
 
-    output = parsed_to_jsonais(parsed, 'Sta', 'http://x.com', rxtime='20260101000000')
+    output = parsed_to_jsonais(parsed, 'Sta', rxtime='20260101000000')
     msg = output['groups'][0]['msgs'][0]
 
     assert msg['callsign'] == 'ABCD'
@@ -117,12 +117,12 @@ def test_build_jsonais_batch():
         {'msgtype': 5, 'mmsi': 222, 'rxtime': '20260101000000'},
     ]
 
-    output = build_jsonais_batch(msgs, 'TestStation', 'http://example.com/post', rxtime='20260101000000')
+    output = build_jsonais_batch(msgs, 'TestStation', rxtime='20260101000000')
 
     assert output['protocol'] == 'jsonais'
     assert output['encodetime'] == '20260101000000'
     group = output['groups'][0]
-    assert group['path'] == [{'name': 'TestStation', 'url': 'http://example.com/post'}]
+    assert group['path'] == [{'name': 'TestStation'}]
     assert group['msgs'] == msgs
     assert len(group['msgs']) == 2
 

--- a/test_ais_json.py
+++ b/test_ais_json.py
@@ -1,5 +1,5 @@
 from unittest.mock import patch, MagicMock
-from ais_json import parsed_to_jsonais, post_jsonais
+from ais_json import parsed_to_jsonais, parsed_to_ais_msg, build_jsonais_batch, post_jsonais, AISCache
 
 
 def test_parsed_to_jsonais_position_report():
@@ -84,3 +84,94 @@ def test_post_jsonais(mock_post):
     assert call_args[0][0] == 'http://example.com/post'
     assert 'jsonais' in call_args[1]['files']
     assert r.status_code == 200
+
+
+def test_parsed_to_ais_msg():
+    parsed = {
+        'id': 1,
+        'mmsi': 211234567,
+        'x': 24.9384,
+        'y': 60.1699,
+        'sog': 12.3,
+        'cog': 45.6,
+        'true_heading': 47,
+        'nav_status': 0,
+    }
+
+    msg = parsed_to_ais_msg(parsed, rxtime='20260223120000')
+
+    assert msg['msgtype'] == 1
+    assert msg['mmsi'] == 211234567
+    assert msg['lon'] == 24.9384
+    assert msg['lat'] == 60.1699
+    assert msg['speed'] == 12.3
+    assert msg['course'] == 45.6
+    assert msg['heading'] == 47
+    assert msg['status'] == 0
+    assert msg['rxtime'] == '20260223120000'
+
+
+def test_build_jsonais_batch():
+    msgs = [
+        {'msgtype': 1, 'mmsi': 111, 'rxtime': '20260101000000'},
+        {'msgtype': 5, 'mmsi': 222, 'rxtime': '20260101000000'},
+    ]
+
+    output = build_jsonais_batch(msgs, 'TestStation', 'http://example.com/post', rxtime='20260101000000')
+
+    assert output['protocol'] == 'jsonais'
+    assert output['encodetime'] == '20260101000000'
+    group = output['groups'][0]
+    assert group['path'] == [{'name': 'TestStation', 'url': 'http://example.com/post'}]
+    assert group['msgs'] == msgs
+    assert len(group['msgs']) == 2
+
+
+def test_cache_keeps_latest_per_mmsi_and_type():
+    cache = AISCache()
+    cache.add({'mmsi': 111, 'msgtype': 1, 'lon': 1.0, 'lat': 2.0, 'speed': 5.0})
+    cache.add({'mmsi': 111, 'msgtype': 1, 'lon': 1.1, 'lat': 2.1, 'speed': 6.0})
+
+    msgs = cache.flush(now=1000.0)
+
+    assert len(msgs) == 1
+    assert msgs[0]['lon'] == 1.1
+    assert msgs[0]['speed'] == 6.0
+
+
+def test_cache_position_dedup():
+    cache = AISCache()
+
+    cache.add({'mmsi': 111, 'msgtype': 1, 'lon': 1.0, 'lat': 2.0})
+    msgs1 = cache.flush(now=1000.0)
+    assert len(msgs1) == 1
+
+    # Same position within 120s - should be deduplicated
+    cache.add({'mmsi': 111, 'msgtype': 1, 'lon': 1.0, 'lat': 2.0})
+    msgs2 = cache.flush(now=1050.0)
+    assert len(msgs2) == 0
+
+
+def test_cache_position_dedup_changed_position():
+    cache = AISCache()
+
+    cache.add({'mmsi': 111, 'msgtype': 1, 'lon': 1.0, 'lat': 2.0})
+    cache.flush(now=1000.0)
+
+    # Changed position within 120s - should pass through
+    cache.add({'mmsi': 111, 'msgtype': 1, 'lon': 1.5, 'lat': 2.5})
+    msgs = cache.flush(now=1050.0)
+    assert len(msgs) == 1
+    assert msgs[0]['lon'] == 1.5
+
+
+def test_cache_position_dedup_expired():
+    cache = AISCache()
+
+    cache.add({'mmsi': 111, 'msgtype': 1, 'lon': 1.0, 'lat': 2.0})
+    cache.flush(now=1000.0)
+
+    # Same position but after 120s - should pass through
+    cache.add({'mmsi': 111, 'msgtype': 1, 'lon': 1.0, 'lat': 2.0})
+    msgs = cache.flush(now=1200.0)
+    assert len(msgs) == 1

--- a/test_ais_json.py
+++ b/test_ais_json.py
@@ -175,3 +175,23 @@ def test_cache_position_dedup_expired():
     cache.add({'mmsi': 111, 'msgtype': 1, 'lon': 1.0, 'lat': 2.0})
     msgs = cache.flush(now=1200.0)
     assert len(msgs) == 1
+
+
+def test_cache_ignores_ignored_types():
+    cache = AISCache()
+
+    for msgtype in [7, 10, 11, 12, 13, 15, 16, 20, 22, 23]:
+        cache.add({'mmsi': 111, 'msgtype': msgtype})
+
+    msgs = cache.flush(now=1000.0)
+    assert len(msgs) == 0
+
+
+def test_cache_accepts_non_ignored_types():
+    cache = AISCache()
+
+    cache.add({'mmsi': 111, 'msgtype': 1, 'lon': 1.0, 'lat': 2.0})
+    cache.add({'mmsi': 222, 'msgtype': 5})
+
+    msgs = cache.flush(now=1000.0)
+    assert len(msgs) == 2


### PR DESCRIPTION
This PR implements position packet deduplication and batch uploads of AIS messages, as required by aprs.fi. Doing this will avoid API rate limiting and provide more efficient data ingestion. It also drops uninteresting message types which would be dropped by the API anyway.

- Hessu (of aprs.fi)